### PR TITLE
feat: delete storages

### DIFF
--- a/Ecommerce/Areas/Admin/Controllers/StorageController.cs
+++ b/Ecommerce/Areas/Admin/Controllers/StorageController.cs
@@ -63,6 +63,19 @@ namespace Ecommerce.Areas.Admin.Controllers
             }
             return View(storage);
         }
+
+        [HttpPost]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var storage = await _unitOfWork.Storage.Get(id);
+            if (storage == null)
+            {
+                return Json(new { success = false, message = "Error while deleting" });
+            }
+            _unitOfWork.Storage.Remove(storage);
+            await _unitOfWork.Save();
+            return Json(new { success = true, message = "Delete successful" });
+        }
         #endregion
     }
 }

--- a/Ecommerce/wwwroot/js/storage-load-table.js
+++ b/Ecommerce/wwwroot/js/storage-load-table.js
@@ -39,3 +39,29 @@ function loadDataTable() {
         ]
     });
 }
+
+function Delete(url) {
+    swal({
+        title: "Are you sure you want to delete?",
+        text: "You will not be able to restore the data",
+        icon: "warning",
+        buttons: true,
+        dangerMode: true
+    }).then((willDelete) => {
+        if (willDelete) {
+            $.ajax({
+                type: "POST",
+                url: url,
+                success: function (data) {
+                    if (data.success) {
+                        toastr.success(data.message);
+                        dataTable.ajax.reload();
+                    }
+                    else {
+                        toastr.error(data.message);
+                    }
+                }
+            });
+        }
+    });
+}   


### PR DESCRIPTION
# Summary

- Create a new endpoint for `Storage` deletion in the `StorageController` class.
- Implement the `Delete` function in the `storage-load-table.js` file to handle the deletion flow.

# Details

- Admin users can now delete storages.

# Evidences

## Deletion warning alert
![delete-storage](https://github.com/user-attachments/assets/9cec6158-7611-4b70-9fc8-3026bef5ea26)
